### PR TITLE
chore: rollback ansible plugin from 1.1 to 1.0

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -17,5 +17,5 @@ ssh-agent:1.20
 slack:2.45
 timestamper:1.11.8
 workflow-aggregator:2.6
-ansible:1.1
+ansible:1.0
 permissive-script-security:0.6


### PR DESCRIPTION
# Motivation
I want to fix the Ansible duplication output mentioned here https://emnifyteam.slack.com/archives/CG4SW9G4D/p1608136437086800
for that, I want to rollback the Ansible plugin from 1.1 to 1.0 in order to test how it behaves.

# Description
- chore: rollback ansible plugin from 1.1 to 1.0