### PR TITLE
chore: rollback kubernetes plugin from 1.28.3 to 1.25.7

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -6,7 +6,7 @@ docker-workflow:1.25
 github-branch-source:2.9.2
 greenballs:1.15.1
 job-dsl:1.77
-kubernetes:1.28.3
+kubernetes:1.25.7
 parameterized-trigger:2.39
 pipeline-aws:1.43
 pipeline-maven:3.9.3


### PR DESCRIPTION
# Motivation
I want to fix the Ansible duplication output mentioned here https://emnifyteam.slack.com/archives/CG4SW9G4D/p1608136437086800
for that, I want to rollback the Kubernetes plugin from 1.28.3 to 1.25.7.
After quite a long troubleshoot here, we end up between agent jnpl + Ansible plugin possible issue. After that, I decided to give it a try rolling back the Kubernetes plugin, which is responsible for that "agent injection" in the run time, and it works out of the box :D

https://jenkins.oss-eks.dev.emnify.io/job/EGN-Deploy/job/master/124/console

More context https://codimd.oss-eks.dev.emnify.io/ansible_duplicate_output_issue?edit
We should investigate more about the issue in the future, but for the time being, this rollback makes sense.

# Description
- chore: rollback Kubernetes plugin from 1.28.3 to 1.25.7