### PR TITLE
[PF-578]ci: use TF EKS service role

### DIFF
--- a/.jenkins/pods/build_container.yaml
+++ b/.jenkins/pods/build_container.yaml
@@ -1,7 +1,6 @@
 metadata:
-  annotations:
-    iam.amazonaws.com/role: ecr-push-pull
 spec:
+  serviceAccountName: jenkins-ecr
   containers:
     - name: kaniko
       image: gcr.io/kaniko-project/executor:debug-v1.3.0


### PR DESCRIPTION
# Motivation
AS Squad PF
I want to use the Terraform EKS service role,
with that, I can deprecate the kube2iam service in the EKS cluster.

# Description
- ci: use TF EKS service role