### PR TITLE
chore: bump Jenkins to 2.277.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.277.1
+FROM jenkins/jenkins:2.277.3
 
 # skip the setup wizard
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false -Dpermissive-script-security.enabled=true"


### PR DESCRIPTION
# Motivation
I want to update Jenkins LTS for the latest patch version

# Description
- chore: bump Jenkins to 2.277.3